### PR TITLE
Ugly fix for AUTHFAILED

### DIFF
--- a/blog-cz.lua
+++ b/blog-cz.lua
@@ -210,6 +210,11 @@ wget.callbacks.httploop_result = function(url, err, http_stat)
     return wget.actions.ABORT
   end
   
+  if status_code == 0 and err == "AUTHFAILED" then
+	  print("AUTHFAILED, skipping...")
+	  return wget.actions.EXIT
+  end
+  
   if status_code >= 500
     or (status_code >= 400 and status_code ~= 404)
     or status_code  == 0 then

--- a/pipeline.py
+++ b/pipeline.py
@@ -49,7 +49,7 @@ if not WGET_AT:
 #
 # Update this each time you make a non-cosmetic change.
 # It will be added to the WARC files and reported to the tracker.
-VERSION = '20200815.01'
+VERSION = '20200815.02'
 USER_AGENT = 'Archive Team'
 TRACKER_ID = 'blog-cz'
 TRACKER_HOST = 'trackerproxy.meo.ws'


### PR DESCRIPTION
It was discovered that a page (http://simpsons4ever.blog.cz/odeslat-email/autorovi) was giving 401s, and that these (and apparently all 401s) made wget/wget-lua/wget-at give 0 and AUTHFAILED, resulting (I think) in it retrying and eventually crashing. This skips the page if that happens. Very broad, but there's no indication that it occurs only on this specific path.